### PR TITLE
Add embedded security curriculum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 ext {
     curriculumFileName = "arch-sec"
     languages = ["DE", "EN"]
+     suffixTags = ["EMBSEC"]
 }
 
 defaultTasks 'buildDocs'

--- a/docs/00b-basics/00-basics.adoc
+++ b/docs/00b-basics/00-basics.adoc
@@ -4,13 +4,17 @@
 
 == {basics}
 
-include::01-what-to-expect-of-this-module.adoc[{include_configuration}]
+ifeval::["{suffix}" == "EMBSEC"]
+include::embsec/01-what-to-expect-of-this-module.adoc[{include_configuration}]
 
-include::02-curriculum-structure-and-chronological-breakdown.adoc[{include_configuration}]
+include::embsec/02-curriculum-structure-and-chronological-breakdown.adoc[{include_configuration}]
+endif::[]
 
 include::03-timing-didactics-and-more.adoc[{include_configuration}]
 
-include::04-prerequisites-for-this-training.adoc[{include_configuration}]
+ifeval::["{suffix}" == "EMBSEC"]
+include::embsec/04-prerequisites-for-this-training.adoc[{include_configuration}]
+endif::[]
 
 include::05-curriculum-outline.adoc[{include_configuration}]
 

--- a/docs/00b-basics/03-timing-didactics-and-more.adoc
+++ b/docs/00b-basics/03-timing-didactics-and-more.adoc
@@ -2,9 +2,14 @@
 
 
 :recommended-duration-in-days: 3
-:methodical-credits: Specified by module
-:technical-credits: Specified by module
-:communicative-credits: Specified by module
+:methodical-credits: Specified by the module
+:technical-credits: Specified by the module
+:communicative-credits: Specified by the module
+ifeval::["{suffix}" == "EMBSEC"]
+:methodical-credits: 20
+:technical-credits: 10
+:communicative-credits: 0
+endif::[]
 
 // tag::DE[]
 === Dauer, Didaktik und weitere Details
@@ -28,7 +33,7 @@ Lizenzierte Schulungen zu {curriculum-short} tragen zur Zulassung zur abschließ
 // tag::EN[]
 === Duration, Teaching Method and Further Details
 
-The times stated below are recommendations.
+The times stated above are recommendations.
 The duration of a training course on the {curriculum-short} module should be at least {recommended-duration-in-days} days, but may be longer.
 Providers may differ in terms of duration, teaching method, type and structure of the exercises, and the detailed course structure.
 In particular, the curriculum provides no specifications on the nature of the examples and exercises.

--- a/docs/00b-basics/embsec/01-what-to-expect-of-this-module.adoc
+++ b/docs/00b-basics/embsec/01-what-to-expect-of-this-module.adoc
@@ -1,0 +1,19 @@
+// tag::DE[]
+=== Was vermittelt das Modul „{curriculum-short}“?
+
+Das Modul präsentiert den Teilnehmerinnen und Teilnehmern {curriculum-name} als …
+Am Ende des Moduls kennen die Teilnehmerinnen und Teilnehmer … und können …
+// end::DE[]
+
+// tag::EN[]
+=== What does the module “{curriculum-short}” convey?
+
+The module EMBSEC conveys the methods to participants to design an embedded system architecture that
+reflects their security goals. Building on the concepts of the foundation level, the module
+introduces participants to analysis methods to identify protection worthy assets and derive security
+goals for embedded systems. It presents qualities, design patterns and technologies which help in
+achieving security goals and familiarizes participants with common attack patterns. Finally
+techniques to verify and validate security properties are presented. At the end of the module the
+participants know approaches to design embedded architectures with security as a quality in mind,
+and are able to identify security risks and select suitable control measures.
+// end::EN[]

--- a/docs/00b-basics/embsec/02-curriculum-structure-and-chronological-breakdown.adoc
+++ b/docs/00b-basics/embsec/02-curriculum-structure-and-chronological-breakdown.adoc
@@ -1,0 +1,38 @@
+// tag::DE[]
+=== Struktur des Lehrplans und empfohlene zeitliche Aufteilung
+
+[cols="<,>", options="header"]
+|===
+| Inhalt | Empfohlene Mindestdauer (min)
+| 1. Thema mit Einleitung | 180
+| 2. Thema über xz | 150
+| 3. Thema mit viel Theorie | 120
+| 4. Thema mit xy und Beispiel | 180
+| 5. Thema mit abc und d | 210
+| 6. Thema mit Abschlussbeispiel | 120
+| |
+| Summe | 960 (16h)
+
+|===
+
+// end::DE[]
+
+// tag::EN[]
+=== Curriculum Structure and Recommended Durations
+
+[cols="<,>", options="header"]
+|===
+| Content
+| Recommended minimum duration (minutes)
+| 1. Introduction | 120
+| 2. Analysis | 240
+| 3. Verification | 120
+| 4. Cryptography | 90
+| 5. Attacks | 120
+| 6. Solution Approaches | 390
+| |
+| Total | 1080 (18h)
+
+|===
+
+// end::EN[]

--- a/docs/00b-basics/embsec/04-prerequisites-for-this-training.adoc
+++ b/docs/00b-basics/embsec/04-prerequisites-for-this-training.adoc
@@ -1,0 +1,32 @@
+// tag::DE[]
+=== Voraussetzungen
+
+Teilnehmerinnen und Teilnehmer **sollten** folgende Kenntnisse und/oder Erfahrung mitbringen:
+
+- Voraussetzung 1
+- Voraussetzung 2, etc.
+
+**Hilfreich** für das Verständnis einiger Konzepte sind darüber hinaus:
+
+- Kenntnisgruppe 1:
+  * Kenntnis 1
+  * Erfahrung 2
+  * Kenntnis 3
+  * Erfahrung 4
+  * Wissen 5
+// end::DE[]
+
+// tag::EN[]
+=== Prerequisites
+
+Participants **should** have the following prerequisite knowledge:
+
+- Foundations of software architecture, as they are taught in CPSA-F accredited trainings.
+- Practical experience with the implementation and design of embedded systems and typical
+challenges in developing embedded systems.
+
+Knowledge in the following areas may be **helpful** for understanding some concepts:
+
+- Practical experience in designing safety-relevant systems.
+- Practical experience in designing security-relevant systems.
+// end::EN[]

--- a/docs/01-introduction/02-learning-goals.adoc
+++ b/docs/01-introduction/02-learning-goals.adoc
@@ -13,6 +13,10 @@
 Participants know a definition of security and understand it as a quality of the system.
 Participants understand the relationship and trade-offs to other quality attributes.
 
+ifeval::["{suffix}" == "EMBSEC"]
+Definitions can be found for example in ISO/IEC 25010, ISO/SAE 21434 and IEC 62443.
+endif::[]
+
 [[LG-1-2]]
 ==== LG 1-2: Security Properties
 
@@ -28,9 +32,20 @@ Participants understand that maintaining security requires participation and con
 Participants know the typical lifecycle phases (conception, development, production, operation and maintenance, and decommission).
 Participants know at least one example of a security product lifecycle.
 
+ifeval::["{suffix}" == "EMBSEC"]
+Examples of security product lifecycles are presented ISO/SAE 21434, the Microsoft Security Development
+Lifecycle and NIST's Secure Software Development Framework.
+endif::[]
 
 [[LG-1-4]]
 ==== LG 1-4: Security Regulations and standards
 Participants understand the difference between regulations, standards and guidelines.
 Participants know examples of regulations, standards and guidelines regarding security.
+
+ifeval::["{suffix}" == "EMBSEC"]
+Example of security regulations, standards and guidelines  are UN R 155, UN R 156, ISO/SAE 21434,
+FDA Guidelines, NIST Standards such as SP800, IEC 62443, IEC 80001-5-1, IEC 60601-4-5, ISO 270xx and
+ETSI EN 303 645.
+endif::[]
+
 // end::EN[]

--- a/docs/02-analysis/01-duration-terms.adoc
+++ b/docs/02-analysis/01-duration-terms.adoc
@@ -10,9 +10,11 @@ Begriff 1, Begriff 2, Begriff 3
 // end::DE[]
 
 // tag::EN[]
+ifeval::["{suffix}" == "EMBSEC"]
 |===
-| Duration: XXX min | Practice time: XXX min
+| Duration: 120 min | Practice time: 120 min
 |===
+ifeval::["{suffix}" == "EMBSEC"]
 
 === Terms and Principles
 asset, attack path, attack tree, damage scenario, feasibility, impact, risk, security claim, security goal,

--- a/docs/02-analysis/02-learning-goals.adoc
+++ b/docs/02-analysis/02-learning-goals.adoc
@@ -35,6 +35,12 @@ Participants understand what assets are and know typical examples.
 Participants are able to identify assets for a given system.
 Participants are able to identify damage scenarios an attack can cause these assets.
 
+ifeval::["{suffix}" == "EMBSEC"]
+Examples of assets in embedded systems are personally identifiable information, user's health and
+safety, intellectual property, hardware components, cryptographic material and communication
+channels.
+endif::[]
+
 [[LG-2-3]]
 ==== LG 2-3: Threat Modeling
 
@@ -60,4 +66,9 @@ Participants are able to identify and analyze threats for a given system.
 
 Participants understand the goal of assessing the risk of threats and the associated damage scenarios.
 Participants know approaches to classifying and rate attack risks.
+
+ifeval::["{suffix}" == "EMBSEC"]
+Examples for common rating systems are CVSS, ISO/SAE 21434 and MITRE's Medical CVSS rubric.
+endif::[]
+
 // end::EN[]

--- a/docs/03-verification/01-duration-terms.adoc
+++ b/docs/03-verification/01-duration-terms.adoc
@@ -10,9 +10,11 @@ Begriff 1, Begriff 2, Begriff 3
 // end::DE[]
 
 // tag::EN[]
+ifeval::["{suffix}" == "EMBSEC"]
 |===
-| Duration: XXX min | Practice time: XXX min
+| Duration: 90 min | Practice time: 30 min
 |===
+endif::[]
 
 === Terms and Principles
 Dynamic Testing, Static Analysis, Verification, Validation

--- a/docs/04-cryptography/01-duration-terms.adoc
+++ b/docs/04-cryptography/01-duration-terms.adoc
@@ -10,9 +10,11 @@ Begriff 1, Begriff 2, Begriff 3
 // end::DE[]
 
 // tag::EN[]
+ifeval::["{suffix}" == "EMBSEC"]
 |===
-| Duration: XXX min | Practice time: XXX min
+| Duration: 90 min | Practice time: 0 min
 |===
+endif::[]
 
 === Terms and Principles
 Asymmetric Cryptography, Entropy, Hashing, Key, Post-Quantum Cryptography, Secret, Symmetric Cryptography, Randomness

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -8,3 +8,24 @@ Dieser Abschnitt enthält Quellenangaben, die ganz oder teilweise im Curriculum 
 // tag::EN[]
 This section contains references that are cited in the curriculum.
 // end::EN[]
+
+ifeval::["{suffix}" == "EMBSEC"]
+**C**
+
+- [[[cve, CVE-Database]]] The MITRE Cooperation: Common Vulnerabilities and Exposures. https://www.cwe.org/
+- [[[cwe, CVE-Database]]] The MITRE Cooperation: Common Weakness Enumeration. https://cwe.mitre.org/
+
+**F**
+
+- [[[fernandez13, Fernandez-Buglioni 2013]]] Fernandez-Buglioni, F: Security Patterns in Practice: Designing Secure Architectures Using Software Patterns. Wiley, 2013
+
+**O**
+
+- [[[owasptop10, OWASP Top 10]]] Open Web Application Security Project: Top 10 Web Application Security Risks. https://owasp.org/www-project-top-ten/, 2021
+- [[[owasptop10iot, OWASP IoT Top 10]]] Open Web Application Security Project: OWASP Top 10 Internet of Things 2018. https://owasp.org/www-project-internet-of-things/, 2018
+
+**S**
+
+- [[[schumacher06, Schumacher 2006]]] Schumacher, M. Fernandez-Buglioni, F., et al.: Security Patterns: Integrating Security and Systems Engineering. Wiley, 2006
+
+endif::[]

--- a/docs/arch-sec.adoc
+++ b/docs/arch-sec.adoc
@@ -48,5 +48,13 @@ include::03-verification/00-structure.adoc[{include_configuration}]
 <<<
 include::04-cryptography/00-structure.adoc[{include_configuration}]
 
+ifeval::["{suffix}" == "EMBSEC"]
+<<<
+include::embsec/05-attacks/00-structure.adoc[{include_configuration}]
+
+<<<
+include::embsec/06-approaches/00-structure.adoc[{include_configuration}]
+endif::[]
+
 <<<
 include::99-references/00-references.adoc[{include_configuration}]

--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -13,13 +13,19 @@
 :include_configuration: tags=**;{language};!*
 
 :curriculum-short: ARCH-SEC
+ifeval::["{suffix}" == "EMBSEC"]
+:curriculum-short: EMBSEC
+endif::[]
+
+:curriculum-name: Architecture Security Core
+ifeval::["{suffix}" == "EMBSEC"]
+:curriculum-name: Embedded Security for Architects
+endif::[]
 
 ifeval::["{language}" == "DE"]
-:curriculum-name: Architecture Security Core
 :curriculum-header-title: iSAQB-Curriculum für Advanced Level: {curriculum-short}
 endif::[]
 
 ifeval::["{language}" == "EN"]
-:curriculum-name: Architecture Security Core
 :curriculum-header-title: iSAQB curriculum for Advanced Level: {curriculum-short}
 endif::[]

--- a/docs/embsec/05-attacks/00-structure.adoc
+++ b/docs/embsec/05-attacks/00-structure.adoc
@@ -1,0 +1,18 @@
+// header file for curriculum section 4: Lerneinheit 4
+// (c) iSAQB e.V. (https://isaqb.org)
+// ====================================================
+
+// tag::DE[]
+== Angriffe
+// end::DE[]
+
+// tag::EN[]
+== Attacks
+// end::EN[]
+
+include::01-duration-terms.adoc[{include_configuration}]
+
+include::02-learning-goals.adoc[{include_configuration}]
+
+// references (if any!)
+include::references.adoc[{include_configuration}]

--- a/docs/embsec/05-attacks/01-duration-terms.adoc
+++ b/docs/embsec/05-attacks/01-duration-terms.adoc
@@ -6,6 +6,7 @@
 === Begriffe und Konzepte
 Begriff 1, Begriff 2, Begriff 3
 
+
 // end::DE[]
 
 // tag::EN[]
@@ -16,5 +17,5 @@ ifeval::["{suffix}" == "EMBSEC"]
 endif::[]
 
 === Terms and Principles
-Quality Attribute, Security, Secure Development Lifecycle, Security Property
+Attack, Attack Surface, CVE, CWE, Threat Agent, Vulnerability, Weakness
 // end::EN[]

--- a/docs/embsec/05-attacks/02-learning-goals.adoc
+++ b/docs/embsec/05-attacks/02-learning-goals.adoc
@@ -1,0 +1,52 @@
+=== {learning-goals}
+
+// tag::DE[]
+[[LZ-5-1]]
+==== LZ 5-1: Dies ist das erste Lernziel in Kapitel 4, das mit xyz
+
+Hier wird beschrieben, was Teilnehmer:innen in diesem Lernziel lernen sollen. Das kann in Prosa-Text
+in ganzen Sätzen oder in Aufzählungen mit Unterpunkten erfolgen. Dabei kann auch unterschieden werden,
+wie wichtig einzelne Aspekte des Lernziels sind. Es kann hier bereits auf Literatur verwiesen werden.
+
+* Erstes Teilziel
+* Zweites Unterthema
+* Dritter Aspekt
+
+[[LZ-5-2]]
+==== LZ 5-2: Hier ist ein zweites Lernziel in diesem Kapitel
+tbd.
+
+// end::DE[]
+
+// tag::EN[]
+[[LG-5-1]]
+==== LG 5-1: Attacker Motivations and Knowledge
+
+Participants know the levels of capabilities (script kiddy, programmer, security expert, state
+actor/competitor, etc.) and motivations (fun, research, monetary gain, etc.) attackers exhibit.
+They should understand the issues with attacker-based risk approaches.
+
+
+[[LG-5-2]]
+==== LG 5-2: Attack Terminology
+
+Participants understand the difference between weaknesses and vulnerabilities.
+They understand the concept of an attack surface.
+
+[[LG-5-3]]
+==== LG 5-3: Security Information Sources
+
+Participants know sources from which information about attacks, vulnerabilities and weaknesses can
+be gathered (e.g., CVE and CWE database, OWASP, SANS Institute, CISA, BSI or UN R 155 for automotive).
+
+[[LG-5-4]]
+==== LG 5-4: Common Attack Patterns
+
+Participants understand typical weaknesses, attack patterns and their effects.
+Examples for these are overflows, injections, privilege escalations, denial of service,
+attacker-in-the-middle, reverse engineering, social engineering.
+Further examples can be found in the OWASP (IoT) Top 10 and aforementioned security information
+sources.
+
+// end::EN[]
+

--- a/docs/embsec/05-attacks/references.adoc
+++ b/docs/embsec/05-attacks/references.adoc
@@ -1,0 +1,10 @@
+=== {references}
+
+<<cve>>, <<cwe>>, <<owasptop10>>, <<owasptop10iot>>
+
+// tag::DE[]
+// silence asciidoctor warnings
+// end::DE[]
+// tag::EN[]
+// silence asciidoctor warnings
+// end::EN[]

--- a/docs/embsec/06-approaches/00-structure.adoc
+++ b/docs/embsec/06-approaches/00-structure.adoc
@@ -1,0 +1,18 @@
+// header file for curriculum section 4: Lerneinheit 4
+// (c) iSAQB e.V. (https://isaqb.org)
+// ====================================================
+
+// tag::DE[]
+== Lösungsansätze
+// end::DE[]
+
+// tag::EN[]
+== Solution Approaches
+// end::EN[]
+
+include::01-duration-terms.adoc[{include_configuration}]
+
+include::02-learning-goals.adoc[{include_configuration}]
+
+// references (if any!)
+include::references.adoc[{include_configuration}]

--- a/docs/embsec/06-approaches/01-duration-terms.adoc
+++ b/docs/embsec/06-approaches/01-duration-terms.adoc
@@ -6,15 +6,16 @@
 === Begriffe und Konzepte
 Begriff 1, Begriff 2, Begriff 3
 
+
 // end::DE[]
 
 // tag::EN[]
 ifeval::["{suffix}" == "EMBSEC"]
 |===
-| Duration: 90 min | Practice time: 30 min
+| Duration: 200 min | Practice time: 190 min
 |===
-endif::[]
+ifeval::["{suffix}" == "EMBSEC"]
 
 === Terms and Principles
-Quality Attribute, Security, Secure Development Lifecycle, Security Property
+Security by Design
 // end::EN[]

--- a/docs/embsec/06-approaches/02-learning-goals.adoc
+++ b/docs/embsec/06-approaches/02-learning-goals.adoc
@@ -1,0 +1,122 @@
+=== {learning-goals}
+
+// tag::DE[]
+[[LZ-6-1]]
+==== LZ 6-1: Dies ist das erste Lernziel in Kapitel 4, das mit xyz
+
+Hier wird beschrieben, was Teilnehmer:innen in diesem Lernziel lernen sollen. Das kann in Prosa-Text
+in ganzen Sätzen oder in Aufzählungen mit Unterpunkten erfolgen. Dabei kann auch unterschieden werden,
+wie wichtig einzelne Aspekte des Lernziels sind. Es kann hier bereits auf Literatur verwiesen werden.
+
+* Erstes Teilziel
+* Zweites Unterthema
+* Dritter Aspekt
+
+[[LZ-6-2]]
+==== LZ 6-2: Hier ist ein zweites Lernziel in diesem Kapitel
+tbd.
+
+// end::DE[]
+
+// tag::EN[]
+[[LG-6-1]]
+==== LG 6-1: Security as a Quality
+
+Participants understand security as a system quality and its relation to other quality requirements.
+Participants understand security as a quality in the context of ISO 25010 and the relation of these
+qualities to the threat modeling analysis technique STRIDE.
+Participants understand that security is a cross-cutting concern, that needs to be addressed at the
+system, hardware and software level.
+
+[[LG-6-2]]
+==== LG 6-2: Guiding Principles
+
+Participants understand the guiding principles to building secure systems, examples include:
+
+* Modular design
+* Defense in depth
+* Least-privilege Principle
+* Data Minimization
+* Self-protection
+* Non-circumventable
+* (No) Security by Obscurity
+* Input and Output Validation
+* Zero Trust
+
+[[LG-6-3]]
+==== LG 6-3: Authentication and Authorization
+
+Participants know methods, patterns and technologies to ensure authentication of entities and manage
+authorization for actions taken on the system.
+
+Examples for these are
+
+* Access Control Lists,
+* the Authenticator Pattern,
+* Capabilities,
+* Credentials,
+* Mandatory Access Control,
+* Multi-Factor Authentication,
+* Multi-Level Security and
+* Session Management.
+
+[[LG-6-4]]
+==== LG 6-4: System Integrity
+
+Participants know methods, patterns and technologies to ensure the system's integrity and protect
+the system against tampering.
+
+Examples are
+
+* immutability,
+* run-time only mutability,
+* Secure Boot,
+* the Trusted Computing concept,
+* handling of  persistent mutable data,
+* Isolation and Sandboxing,
+* Hardware Memory Protection,
+* Software Memory Protection and
+* Resource Exhaustion protections.
+
+[[LG-6-5]]
+==== LG 6-5: Software Updates
+
+Participants understand the need for software updates and the challenges deploying updates to embedded
+devices pose.
+Participants know the security trade-off of updatable devices.
+Participants know possible solutions to securely deploy updates to embedded devices (e.g., signed
+and encrypted firmware packages, secure version numbers)
+
+[[LG-6-6]]
+==== LG 6-6: Communication
+
+Participants understand the necessity of ensuring confidentiality, integrity and availability of
+communication.
+Participants know mechanisms to harden communication against attacks such as
+
+* encryption (e.g., with AEAD algorithms),
+* firewalls,
+* segregation and
+* security protocols such as MACSec, IPSec, TLS or
+* Secure On-Board Communication.
+
+[[LG-6-7]]
+==== LG 6-7: Secure Implementation
+
+Participants understand how a well engineered implementation supports the security goals.
+Participants know standards and guidelines to reduce the likelihood of introducing defects during
+the implementation such as MISRA, CERT Coding Guidelines or OWASP's Secure Coding Practices.
+
+[[LG-6-8]]
+==== LG 6-8: Hardware Security
+
+Participants understand what role the underlying hardware plays in achieving security goals.
+Participants know how isolation concept can be realized with hardware support, what a Hardware
+Security Module or a Trusted Platform Module is.
+Participants know examples of hardware security mechanisms such as Physical Unclonable Functions or
+Fuses.
+Participants know that hardware interfaces might need to be disabled for a production deployment,
+e.g., serial and debug interfaces
+
+
+// end::EN[]

--- a/docs/embsec/06-approaches/references.adoc
+++ b/docs/embsec/06-approaches/references.adoc
@@ -1,0 +1,10 @@
+=== {references}
+
+<<fernandez13>>, <<schumacher06>>
+
+// tag::DE[]
+// silence asciidoctor warnings
+// end::DE[]
+// tag::EN[]
+// silence asciidoctor warnings
+// end::EN[]


### PR DESCRIPTION
Without nested tag support a build version of this PR can be found at https://github.com/Gronner/arch-sec/tree/emb-sec-tagless or by running

```
find . -type f -name "*.adoc" -exec sed -i 's#ifeval::\["\{suffix\}" == "EMBSEC"\]##g' {} +;
find . -type f -name "*.adoc" -exec sed -i 's#endif::\[\]##g' {} +;
```
within the repository.

Currently support for the configuration is yet missing in `docs/config/setup.adoc`.